### PR TITLE
Update to use .NET 8 RTM

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 8.0.100-rc.2.23502.2
+        dotnet-version: 8.0.100
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/EFCore.ConfigurationManager.Tests/EFCore.ConfigurationManager.Tests.csproj
+++ b/EFCore.ConfigurationManager.Tests/EFCore.ConfigurationManager.Tests.csproj
@@ -11,13 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0-rc.2.23480.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0-rc.2.23480.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/EFCore.ConfigurationManager/EFCore.ConfigurationManager.csproj
+++ b/EFCore.ConfigurationManager/EFCore.ConfigurationManager.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>EntityFrameworkCore.ConfigurationManager</AssemblyName>
     <RootNamespace>EntityFrameworkCore.ConfigurationManager</RootNamespace>
     <Authors>Brice Lambson</Authors>
@@ -17,12 +17,12 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>https://github.com/efcore/EFCore.ConfigurationManager/releases</PackageReleaseNotes>
-    <Version>2.0.0</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following table shows which version of this library to use with which versio
 
 EF Core              | Version to use
 -------------------- | --------------
-8.0                  | 2.x
+8.0                  | 3.x
 7.0                  | 2.x
 6.0                  | 2.x
 3.1 (Out of support) | 1.x


### PR DESCRIPTION
Update test dependencies

Use 8.0 System.Configuration.ConfigurationManager that has less dependencies than the the 6.0 version (including System.Common.Drawing!)